### PR TITLE
handle shifted characters for key.input

### DIFF
--- a/pub/inputs.js
+++ b/pub/inputs.js
@@ -24,27 +24,37 @@ document.body.onkeydown = function(e) {
 			let code = 0;
 
 			let keyCodeLookUp = {
-				"Semicolon":    { key: ";",  keyCode: 186 },
-				"Equal":        { key: "=",  keyCode: 187 },
-				"Comma":        { key: ",",  keyCode: 188 },
-				"Minus":        { key: "-",  keyCode: 189 },
-				"Period":       { key: ".",  keyCode: 190 },
-				"Slash":        { key: "/",  keyCode: 191 },
-				"Backquote":    { key: "`",  keyCode: 192 },
-				"BracketLeft":  { key: "[",  keyCode: 219 },
-				"Backslash":    { key: "\\", keyCode: 220 },
-				"BracketRight": { key: "]",  keyCode: 221 },
-				"Quote":        { key: "'",  keyCode: 222 }
+				"Semicolon":    { key: ";",  keyCode: 186, shiftKey: ":"},
+				"Equal":        { key: "=",  keyCode: 187, shiftKey: "+"},
+				"Comma":        { key: ",",  keyCode: 188, shiftKey: "<"},
+				"Minus":        { key: "-",  keyCode: 189, shiftKey: "_"},
+				"Period":       { key: ".",  keyCode: 190, shiftKey: ">"},
+				"Slash":        { key: "/",  keyCode: 191, shiftKey: "?"},
+				"Backquote":    { key: "`",  keyCode: 192, shiftKey: "~"},
+				"BracketLeft":  { key: "[",  keyCode: 219, shiftKey: "{"},
+				"Backslash":    { key: "\\", keyCode: 220, shiftKey: "|"},
+				"BracketRight": { key: "]",  keyCode: 221, shiftKey: "}"},
+				"Quote":        { key: "'",  keyCode: 222, shiftKey: "\""}
 			};
 
-			if (e.code.includes("Key") || e.code.includes("Digit")) {
+			if (e.code.includes("Key")) {
 				// we can get the input key and code by using the last character of e.code
-				input = e.code.charAt(e.code.length - 1).toLowerCase();
+				let char = e.code.charAt(e.code.length - 1);
+
+				if (inputs.mod.shift) {
+					input = char;
+				} else {
+					input = char.toLowerCase();
+				}
 				code = e.code.charCodeAt(e.code.length - 1);
 			} else if (keyCodeLookUp[e.code]) {
 				// use the lookup object for characters which are changed on different
 				// keyboard layouts but aren't letters or digits
-				input = keyCodeLookUp[e.code].key;
+				if (inputs.mod.shift) {
+					input = keyCodeLookUp[e.code].shiftKey;
+				} else {
+					input = keyCodeLookUp[e.code].key;
+				}
 				code = keyCodeLookUp[e.code].keyCode;
 			} else {
 				// usually if key is universal, e.g. arrow keys


### PR DESCRIPTION
this closes #55 
my bad for not handling shifted characters, maybe i was expecting everything to be handled using shift/meta boolean states and keycodes, this bug slipped under my radar.
this should correctly throw shifted letter characters, shift symbols for all number keys and shifted punctuation keys.

for shifting punctuation, i added another property to the lookup table called `shiftKey`, which describes the character used when the specific key is shifted. a lookup table is still required here, otherwise there would be a weird discrepancy between the non-shifted and shifted characters, keeping in mind that dvorak (and therefore other layouts) has some punctuation/symbol keys where letter keys are normally on a standard US qwerty layout.

make sure to test! i think i've tested all the key commands, at least the ones that don't interfere with my window manager shortcuts